### PR TITLE
Version 0.0.6: Trajectories codec delete useless measurements, deleted signalStrength ID and added variance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This codec allows to encode measurements matching this pattern :
   [ 
     {
       signal_strength: int,
-      std: int // standard deviation
+      std: int // standard deviation (optionnal)
     },
     ...
   ] 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This codec allows to encode measurements matching this pattern :
   [ 
     {
       signal_strength: int,
-      variance: float // variance is optionnal
+      std: int // standard deviation
     },
     ...
   ] 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This codec allows to encode measurements matching this pattern :
   [ 
     {
       signal_strength: int,
-      ID: uint32 // ID is optionnal
+      variance: float // variance is optionnal
     },
     ...
   ] 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pheromon-codecs",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "Function to encode data used by pheromon sources ",
     "main": "./index.js",
     "scripts": {

--- a/signalStrengths/MIN_DATE_UNIX_TIMESTAMP.js
+++ b/signalStrengths/MIN_DATE_UNIX_TIMESTAMP.js
@@ -1,5 +1,0 @@
-"use strict";
-
-var moment = require('moment');
-
-module.exports = moment("2015-05-15").unix();

--- a/signalStrengths/MIN_SIGNAL_STRENGTH.js
+++ b/signalStrengths/MIN_SIGNAL_STRENGTH.js
@@ -1,3 +1,0 @@
-"use strict";
-
-module.exports = -110;

--- a/signalStrengths/codec.js
+++ b/signalStrengths/codec.js
@@ -6,4 +6,4 @@ var decode = require('./decode.js');
 module.exports = {
 	encode: encode,
 	decode: decode
-}
+};

--- a/signalStrengths/decode.js
+++ b/signalStrengths/decode.js
@@ -4,12 +4,13 @@ require('es6-shim');
 var decodeProtoDelta = require('./decodeMeasurement-delta-protobuf');
 var unshrinkMeasurementInformation = require('./unshrinkMeasurementInformation');
 
-
-module.exports = function decode(buffer){
+// buffer : buffer to decode
+// options : {minDateUnixTimestamp: integer, minSignalStrength: integer in dB}
+module.exports = function decode(buffer, options){
     return new Promise(function(resolve, reject){
         resolve(decodeProtoDelta(buffer));
     })
     .then(function(measurement){
-        return unshrinkMeasurementInformation(measurement);
-    })
-}
+        return unshrinkMeasurementInformation(measurement, options);
+    });
+};

--- a/signalStrengths/decodeMeasurement-delta-protobuf.js
+++ b/signalStrengths/decodeMeasurement-delta-protobuf.js
@@ -6,19 +6,23 @@ var path = require('path');
 var protobuf = require('protocol-buffers');
 
 var deltaDecode = require('./delta-decode');
+var deltaDecode2 = require('../trajectories/delta-decode');
+
 
 var message = protobuf(fs.readFileSync(path.join(__dirname, '/delta-encoded-measurement.proto')));
 
 module.exports = function(buffer){
     var measurement = message.AffluenceSensorMeasurement.decode(buffer);
     var signal_strengths;
+    var stds;
     
     signal_strengths = deltaDecode(measurement.signal_strengths);
+    stds = deltaDecode2(measurement.stds);
 
     var devices = signal_strengths.map(function (signal_strength, index) {
         return {
             signal_strength: signal_strength,
-            variance: measurement.variances[index]
+            std: stds ? stds[index] : undefined
         };
     });
 

--- a/signalStrengths/decodeMeasurement-delta-protobuf.js
+++ b/signalStrengths/decodeMeasurement-delta-protobuf.js
@@ -18,7 +18,7 @@ module.exports = function(buffer){
     var devices = signal_strengths.map(function (signal_strength, index) {
         return {
             signal_strength: signal_strength,
-            ID: measurement.IDs[index]
+            variance: measurement.variances[index]
         };
     });
 

--- a/signalStrengths/delta-encoded-measurement.proto
+++ b/signalStrengths/delta-encoded-measurement.proto
@@ -1,5 +1,5 @@
 message AffluenceSensorMeasurement {
   required uint32 date = 1;
   required bytes signal_strengths = 2 [packed=true];
-  repeated float variances = 3 [packed=true];
+  optional bytes stds = 3 [packed=true];
 }

--- a/signalStrengths/delta-encoded-measurement.proto
+++ b/signalStrengths/delta-encoded-measurement.proto
@@ -1,5 +1,5 @@
 message AffluenceSensorMeasurement {
   required uint32 date = 1;
   required bytes signal_strengths = 2 [packed=true];
-  repeated uint32 IDs = 3 [packed=true];
+  repeated float variances = 3 [packed=true];
 }

--- a/signalStrengths/encode.js
+++ b/signalStrengths/encode.js
@@ -3,15 +3,19 @@ require('es6-shim');
 
 var encodeProtoDelta = require('./encodeMeasurement-delta-protobuf');
 var shrinkMeasurementInformation = require('./shrinkMeasurementInformation');
+var moment = require('moment');
 
-module.exports = function encode(measurement){
+
+// measurement : measurement to encode
+// options : {minDateUnixTimestamp: integer, minSignalStrength: integer in dB}
+module.exports = function encode(measurement, options){
 
     return new Promise(function(resolve, reject){
 
         if (measurement.date === undefined || measurement.devices === undefined)
             reject("Cannot encode this object : wrong format");
 
-        var shrinkedMessage = shrinkMeasurementInformation(measurement);
+        var shrinkedMessage = shrinkMeasurementInformation(measurement, options);
         var delta_protobuf_based_buffer = encodeProtoDelta(shrinkedMessage);
 
     if (delta_protobuf_based_buffer)

--- a/signalStrengths/encodeMeasurement-delta-protobuf.js
+++ b/signalStrengths/encodeMeasurement-delta-protobuf.js
@@ -5,13 +5,14 @@ var path = require('path');
 var protobuf = require('protocol-buffers');
 
 var deltaEncode = require('./delta-encode');
+var deltaEncode2 = require('../trajectories/delta-encode');
 
 var message = protobuf(fs.readFileSync(path.join(__dirname, '/delta-encoded-measurement.proto')));
 
 module.exports = function(measurement){
 
-    var variances = measurement.devices.map(function (device) {
-        return device.variance;
+    var stds = measurement.devices.map(function (device) {
+        return device.std;
     });
 
     var signal_strengths = measurement.devices.map(function (device) {
@@ -21,6 +22,6 @@ module.exports = function(measurement){
     return message.AffluenceSensorMeasurement.encode({
         date: measurement.date,
         signal_strengths: deltaEncode(signal_strengths),
-        variances: variances
+        stds: deltaEncode2(stds)
     });
 };

--- a/signalStrengths/encodeMeasurement-delta-protobuf.js
+++ b/signalStrengths/encodeMeasurement-delta-protobuf.js
@@ -10,8 +10,8 @@ var message = protobuf(fs.readFileSync(path.join(__dirname, '/delta-encoded-meas
 
 module.exports = function(measurement){
 
-    var IDs = measurement.devices.map(function (device) {
-        return device.ID;
+    var variances = measurement.devices.map(function (device) {
+        return device.variance;
     });
 
     var signal_strengths = measurement.devices.map(function (device) {
@@ -21,6 +21,6 @@ module.exports = function(measurement){
     return message.AffluenceSensorMeasurement.encode({
         date: measurement.date,
         signal_strengths: deltaEncode(signal_strengths),
-        IDs: IDs
+        variances: variances
     });
 };

--- a/signalStrengths/shrinkMeasurementInformation.js
+++ b/signalStrengths/shrinkMeasurementInformation.js
@@ -33,7 +33,7 @@ module.exports = function shrinkMeasurementInformation(measurement){
     var devices = devices.map(function (device) {
         return {
             signal_strength: toByte(device.signal_strength),
-            ID: device.ID
+            variance: device.variance
         };
     });
 

--- a/signalStrengths/shrinkMeasurementInformation.js
+++ b/signalStrengths/shrinkMeasurementInformation.js
@@ -2,20 +2,22 @@
 
 var moment = require('moment');
 
-var MIN_DATE_UNIX_TIMESTAMP = require('./MIN_DATE_UNIX_TIMESTAMP');
-
-
-var MIN_SIGNAL_STRENGTH = require('./MIN_SIGNAL_STRENGTH');
-// var MAX_SIGNAL_STRENGTH = MIN_SIGNAL_STRENGTH + 255;
-
-function toByte(v){
-    return v - MIN_SIGNAL_STRENGTH;
+function toByte(v, min){
+    return v - min;
 }
 
-/*
+module.exports = function shrinkMeasurementInformation(measurement, options) {
+
+
+    var MIN_DATE_UNIX_TIMESTAMP = moment("2015-05-15").unix();
+    var MIN_SIGNAL_STRENGTH = -110;
+
+    if (options) {
+        MIN_DATE_UNIX_TIMESTAMP = options.minDateUnixTimestamp || MIN_DATE_UNIX_TIMESTAMP;
+        MIN_SIGNAL_STRENGTH = options.minSignalStrength || MIN_SIGNAL_STRENGTH;
+    }
+
     
-*/
-module.exports = function shrinkMeasurementInformation(measurement){
     var date = moment(measurement.date);
     var secondTimestamp = date.unix();
     var recentTimestampSec = secondTimestamp - MIN_DATE_UNIX_TIMESTAMP;
@@ -30,15 +32,15 @@ module.exports = function shrinkMeasurementInformation(measurement){
     });
 
     // shrink signal strengths
-    var devices = devices.map(function (device) {
+    var newDevices = devices.map(function (device) {
         return {
-            signal_strength: toByte(device.signal_strength),
-            variance: device.variance
+            signal_strength: toByte(device.signal_strength, MIN_SIGNAL_STRENGTH),
+            std: Math.round(device.std)
         };
     });
 
     return {
         date: recentTimestampMin,
-        devices: devices
+        devices: newDevices
     };
 };

--- a/signalStrengths/unshrinkMeasurementInformation.js
+++ b/signalStrengths/unshrinkMeasurementInformation.js
@@ -17,12 +17,12 @@ module.exports = function unshrinkMeasurementInformation(measurement){
     
     // Unshrink signal strengths
     var devices = measurement.devices.map(function (device) {
-        device.signal_strength = fromByte(device.signal_strength)
+        device.signal_strength = fromByte(device.signal_strength);
         return device;
-    })
+    });
 
     return {
-        date: unshrinkedDate,
+        date: new Date(unshrinkedDate),
         devices: devices
     };
 };

--- a/signalStrengths/unshrinkMeasurementInformation.js
+++ b/signalStrengths/unshrinkMeasurementInformation.js
@@ -2,22 +2,26 @@
 
 var moment = require('moment');
 
-var MIN_DATE_UNIX_TIMESTAMP = require('./MIN_DATE_UNIX_TIMESTAMP');
-
-var MIN_SIGNAL_STRENGTH = require('./MIN_SIGNAL_STRENGTH');
-
-function fromByte(v){
-    return v + MIN_SIGNAL_STRENGTH;
+function fromByte(v, min){
+    return v + min;
 }
 
-module.exports = function unshrinkMeasurementInformation(measurement){
+module.exports = function unshrinkMeasurementInformation(measurement, options) {
+
+    var MIN_DATE_UNIX_TIMESTAMP = moment("2015-05-15").unix();
+    var MIN_SIGNAL_STRENGTH = -110;
+
+    if (options) {
+        MIN_DATE_UNIX_TIMESTAMP = options.minDateUnixTimestamp || MIN_DATE_UNIX_TIMESTAMP;
+        MIN_SIGNAL_STRENGTH = options.minSignalStrength || MIN_SIGNAL_STRENGTH;
+    }
 
     // Unshrink date
     var unshrinkedDate = moment.unix(measurement.date*60 + MIN_DATE_UNIX_TIMESTAMP);
     
     // Unshrink signal strengths
     var devices = measurement.devices.map(function (device) {
-        device.signal_strength = fromByte(device.signal_strength);
+        device.signal_strength = fromByte(device.signal_strength, MIN_SIGNAL_STRENGTH);
         return device;
     });
 

--- a/tests/signalStrengths/general-test.js
+++ b/tests/signalStrengths/general-test.js
@@ -9,7 +9,7 @@ chai.use(chaiAsPromised);
 
 describe('signalStrengths', function() {
 
-    it('should encode and decode measurement', function() {
+    it('should encode and decode measurement with variance', function() {
 
         var measurement = 
         {
@@ -18,11 +18,11 @@ describe('signalStrengths', function() {
             [
                 {
                     signal_strength: -79,
-                    ID: 42
+                    variance: 42.5
                 },
                 {
                     signal_strength: -30,
-                    ID: 12
+                    variance: 12.2
                 }
             ]
         };
@@ -33,7 +33,48 @@ describe('signalStrengths', function() {
             return signalStrengthsCodec.decode(encoded)
             .then(function (decoded) {
 
-                expect(JSON.stringify(decoded)).to.be.equal(JSON.stringify(measurement));
+                expect(decoded.date.toString()).to.deep.equal(measurement.date.toString());
+                measurement.devices.forEach(function (device, index) {
+                    expect(decoded.devices[index].signal_strength).to.be.deep.equal(device.signal_strength);
+                    if (device.variance)
+                        expect(Math.abs(decoded.devices[index].variance - device.variance)).to.be.most(0.001);
+                    else
+                        expect(decoded.devices[index].variance).to.be.undefined;
+                });
+            });
+        });
+    });
+
+    it('should encode and decode measurement without variance', function() {
+
+        var measurement = 
+        {
+            date: new Date(Math.floor(new Date().getTime() / 60000) * 60000),
+            devices:
+            [
+                {
+                    signal_strength: -79
+                },
+                {
+                    signal_strength: -30
+                }
+            ]
+        };
+
+        return signalStrengthsCodec.encode(measurement)
+        .then(function (encoded) {
+
+            return signalStrengthsCodec.decode(encoded)
+            .then(function (decoded) {
+
+                expect(decoded.date.toString()).to.deep.equal(measurement.date.toString());
+                measurement.devices.forEach(function (device, index) {
+                    expect(decoded.devices[index].signal_strength).to.be.deep.equal(device.signal_strength);
+                    if (device.variance)
+                        expect(Math.abs(decoded.devices[index].variance - device.variance)).to.be.most(0.001);
+                    else
+                        expect(decoded.devices[index].variance).to.be.undefined;
+                });
             });
         });
     });

--- a/tests/signalStrengths/general-test.js
+++ b/tests/signalStrengths/general-test.js
@@ -9,7 +9,7 @@ chai.use(chaiAsPromised);
 
 describe('signalStrengths', function() {
 
-    it('should encode and decode measurement with variance', function() {
+    it('should encode and decode measurement with standard deviation', function() {
 
         var measurement = 
         {
@@ -18,11 +18,11 @@ describe('signalStrengths', function() {
             [
                 {
                     signal_strength: -79,
-                    variance: 42.5
+                    std: 42.5
                 },
                 {
                     signal_strength: -30,
-                    variance: 12.2
+                    std: 0
                 }
             ]
         };
@@ -36,16 +36,16 @@ describe('signalStrengths', function() {
                 expect(decoded.date.toString()).to.deep.equal(measurement.date.toString());
                 measurement.devices.forEach(function (device, index) {
                     expect(decoded.devices[index].signal_strength).to.be.deep.equal(device.signal_strength);
-                    if (device.variance)
-                        expect(Math.abs(decoded.devices[index].variance - device.variance)).to.be.most(0.001);
+                    if (device.std !== undefined)
+                        expect(Math.abs(decoded.devices[index].std - device.std)).to.be.most(0.5);
                     else
-                        expect(decoded.devices[index].variance).to.be.undefined;
+                        expect(decoded.devices[index].std).to.be.undefined;
                 });
             });
         });
     });
 
-    it('should encode and decode measurement without variance', function() {
+    it('should encode and decode measurement without standard deviation', function() {
 
         var measurement = 
         {
@@ -70,10 +70,10 @@ describe('signalStrengths', function() {
                 expect(decoded.date.toString()).to.deep.equal(measurement.date.toString());
                 measurement.devices.forEach(function (device, index) {
                     expect(decoded.devices[index].signal_strength).to.be.deep.equal(device.signal_strength);
-                    if (device.variance)
-                        expect(Math.abs(decoded.devices[index].variance - device.variance)).to.be.most(0.001);
+                    if (device.std !== undefined)
+                        expect(Math.abs(decoded.devices[index].std - device.std)).to.be.most(0.5);
                     else
-                        expect(decoded.devices[index].variance).to.be.undefined;
+                        expect(decoded.devices[index].std).to.be.undefined;
                 });
             });
         });

--- a/trajectories/MIN_DATE_UNIX_TIMESTAMP.js
+++ b/trajectories/MIN_DATE_UNIX_TIMESTAMP.js
@@ -1,3 +1,0 @@
-"use strict";
-
-module.exports = new Date("2015-05-15").getTime() / 1000;

--- a/trajectories/MIN_SIGNAL_STRENGTH.js
+++ b/trajectories/MIN_SIGNAL_STRENGTH.js
@@ -1,3 +1,0 @@
-"use strict";
-
-module.exports = -110;

--- a/trajectories/PRECISION_DATE.js
+++ b/trajectories/PRECISION_DATE.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = 30; // In seconds

--- a/trajectories/PRECISION_SIGNAL_STRENGTH.js
+++ b/trajectories/PRECISION_SIGNAL_STRENGTH.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = 5;

--- a/trajectories/decode.js
+++ b/trajectories/decode.js
@@ -11,7 +11,13 @@ var deltaDecoder = require('./delta-decode');
 var message = protobuf(fs.readFileSync(path.join(__dirname, '/delta-encoded-measurement.proto')));
 
 
-module.exports = function decode(buffer) {
+// trajectories : trajectories to encode
+// options : {minDateUnixTimestamp: integer, 
+//            minSignalStrength: integer in dB,
+//            precisionSignalStrength: integer in dB,
+//            precisionDate: integer in seconds}
+
+module.exports = function decode(buffer, options) {
 
     return new Promise(function (resolve, reject) {
         var unprotobuffed = message.trajectories.decode(buffer);
@@ -36,6 +42,6 @@ module.exports = function decode(buffer) {
             return rebuiltObj;
         });
 
-        resolve(unshrinker(deltaDecoded));
+        resolve(unshrinker(deltaDecoded, options));
     });
 };

--- a/trajectories/delta-decode.js
+++ b/trajectories/delta-decode.js
@@ -18,6 +18,10 @@ function fourBitSigned(nb) { // Set the value of the 4th less significant bit to
 }
 
 module.exports = function(buffer){
+
+    if (!buffer || !buffer.length)
+        return undefined;
+
     var arr = [];
     var previousValue;
     var tmpVarInt = [];

--- a/trajectories/delta-encode.js
+++ b/trajectories/delta-encode.js
@@ -9,6 +9,10 @@ var ESCAPE_VALUE = 0x08; // -8 in 4bit signed binary
 */
 
 module.exports = function(values){
+
+    if (!values || !values.length)
+        return undefined;
+
     // allocate a buffer purposefully too big (REALLY too big, for varInts)
     var buffer = new Buffer(8*values.length);
     var nextIndex = 0;
@@ -17,6 +21,9 @@ module.exports = function(values){
     var vint;
     
     values.forEach(function(v){
+        if (isNaN(v) || v === undefined || v === null)
+            return undefined;
+
         if (previousValue === undefined){
             vint = varInt.encode(v);
 

--- a/trajectories/encode.js
+++ b/trajectories/encode.js
@@ -31,13 +31,18 @@ function isCorrectFormat(trajectories) {
     return true;
 }
 
+// trajectories : trajectories to encode
+// options : {minDateUnixTimestamp: integer, 
+//            minSignalStrength: integer in dB,
+//            precisionSignalStrength: integer in dB,
+//            precisionDate: integer in seconds}
 
-module.exports = function encode(trajectories) {
+module.exports = function encode(trajectories, options) {
     return new Promise(function (resolve, reject) {
         if (!isCorrectFormat(trajectories))
             reject(new Error('Encoding error, format not correct'));
         else {
-            var shrinked = shrinker(trajectories);
+            var shrinked = shrinker(trajectories, options);
 
             var deltaEncoded = shrinked.map(function (trajectory) { // [{date, signal_strength}, ...]
 

--- a/trajectories/shrink.js
+++ b/trajectories/shrink.js
@@ -24,7 +24,6 @@ module.exports = function shrink (trajectories) {
             if (!filtered.slice(-1)[0])
                 filtered.push(measurement);
             else {
-                console.log((measurement.date.getTime() - filtered.slice(-1)[0].date.getTime()) / 1000);
                 if (((measurement.date.getTime() - filtered.slice(-1)[0].date.getTime()) / 1000 >= PRECISION_DATE) &&
                     (Math.abs(measurement.signal_strength - filtered.slice(-1)[0].signal_strength) >= PRECISION_SIGNAL_STRENGTH))
                     filtered.push(measurement);

--- a/trajectories/shrink.js
+++ b/trajectories/shrink.js
@@ -13,9 +13,27 @@ function shrinkSignal(sig) {
     return Math.round(Math.max(sig - MIN_SIGNAL_STRENGTH, 0) / PRECISION_SIGNAL_STRENGTH);
 }
 
+// Shrink measurements (and deleted useless points)
 module.exports = function shrink (trajectories) {
     return trajectories.map(function (trajectory) {
-        return trajectory.map(function (measurement) {
+
+        var filtered = [];
+
+        // Deleted measurements with a date delta or signal delta too low.
+        trajectory.forEach(function (measurement) {
+            if (!filtered.slice(-1)[0])
+                filtered.push(measurement);
+            else {
+                console.log((measurement.date.getTime() - filtered.slice(-1)[0].date.getTime()) / 1000);
+                if (((measurement.date.getTime() - filtered.slice(-1)[0].date.getTime()) / 1000 >= PRECISION_DATE) &&
+                    (Math.abs(measurement.signal_strength - filtered.slice(-1)[0].signal_strength) >= PRECISION_SIGNAL_STRENGTH))
+                    filtered.push(measurement);
+            }
+        });
+
+        // shrink
+        return trajectory
+        .map(function (measurement) {
             return {
                 date: shrinkDate(measurement.date),
                 signal_strength: shrinkSignal(measurement.signal_strength)

--- a/trajectories/shrink.js
+++ b/trajectories/shrink.js
@@ -13,7 +13,7 @@ function shrinkSignal(sig) {
     return Math.round(Math.max(sig - MIN_SIGNAL_STRENGTH, 0) / PRECISION_SIGNAL_STRENGTH);
 }
 
-// Shrink measurements (and deleted useless points)
+// Shrink measurements (and deleted useless measurements)
 module.exports = function shrink (trajectories) {
     return trajectories.map(function (trajectory) {
 

--- a/trajectories/shrink.js
+++ b/trajectories/shrink.js
@@ -1,20 +1,29 @@
 "use strict";
 
-var MIN_DATE_UNIX_TIMESTAMP = require('./MIN_DATE_UNIX_TIMESTAMP');
-var MIN_SIGNAL_STRENGTH = require('./MIN_SIGNAL_STRENGTH');
-var PRECISION_SIGNAL_STRENGTH = require('./PRECISION_SIGNAL_STRENGTH');
-var PRECISION_DATE = require('./PRECISION_DATE');
-
-function shrinkDate(date) {
-    return Math.floor(Math.max(date.getTime() / 1000 - MIN_DATE_UNIX_TIMESTAMP, 0) / PRECISION_DATE);
+function shrinkDate(date, min, precision) {
+    return Math.floor(Math.max(date.getTime() / 1000 - min, 0) / precision);
 }
 
-function shrinkSignal(sig) {
-    return Math.round(Math.max(sig - MIN_SIGNAL_STRENGTH, 0) / PRECISION_SIGNAL_STRENGTH);
+function shrinkSignal(sig, min, precision) {
+    return Math.round(Math.max(sig - min, 0) / precision);
 }
 
 // Shrink measurements (and deleted useless measurements)
-module.exports = function shrink (trajectories) {
+module.exports = function shrink (trajectories, options) {
+
+    var MIN_DATE_UNIX_TIMESTAMP = new Date("2015-05-15").getTime() / 1000; // seconds
+    var MIN_SIGNAL_STRENGTH = -110; // dB
+    var PRECISION_SIGNAL_STRENGTH = 5; // dB
+    var PRECISION_DATE = 30; // seconds
+
+    if (options) {
+        MIN_DATE_UNIX_TIMESTAMP = options.minDateUnixTimestamp || MIN_DATE_UNIX_TIMESTAMP;
+        MIN_SIGNAL_STRENGTH = options.minSignalStrength || MIN_SIGNAL_STRENGTH;
+        PRECISION_SIGNAL_STRENGTH = options.precisionSignalStrength || PRECISION_SIGNAL_STRENGTH;
+        PRECISION_DATE = options.precisionDate || PRECISION_DATE;
+    }
+
+
     return trajectories.map(function (trajectory) {
 
         var filtered = [];
@@ -34,8 +43,8 @@ module.exports = function shrink (trajectories) {
         return trajectory
         .map(function (measurement) {
             return {
-                date: shrinkDate(measurement.date),
-                signal_strength: shrinkSignal(measurement.signal_strength)
+                date: shrinkDate(measurement.date, MIN_DATE_UNIX_TIMESTAMP, PRECISION_DATE),
+                signal_strength: shrinkSignal(measurement.signal_strength, MIN_SIGNAL_STRENGTH, PRECISION_SIGNAL_STRENGTH)
             };
         });
     });

--- a/trajectories/unshrink.js
+++ b/trajectories/unshrink.js
@@ -1,26 +1,33 @@
 "use strict";
 
-var MIN_DATE_UNIX_TIMESTAMP = require('./MIN_DATE_UNIX_TIMESTAMP');
-var MIN_SIGNAL_STRENGTH = require('./MIN_SIGNAL_STRENGTH');
-var PRECISION_SIGNAL_STRENGTH = require('./PRECISION_SIGNAL_STRENGTH');
-var PRECISION_DATE = require('./PRECISION_DATE');
-
-
-function unshrinkDate(shrinkedDate) {
-    return new Date(((shrinkedDate * PRECISION_DATE) + MIN_DATE_UNIX_TIMESTAMP) * 1000);
+function unshrinkDate(shrinkedDate, min, precision) {
+    return new Date(((shrinkedDate * precision) + min) * 1000);
 }
 
 
-function unshrinkSignal(shrinkedSig) {
-    return shrinkedSig * PRECISION_SIGNAL_STRENGTH + MIN_SIGNAL_STRENGTH;
+function unshrinkSignal(shrinkedSig, min, precision) {
+    return shrinkedSig * precision + min;
 }
 
-module.exports = function unshrink (trajectories) {
+module.exports = function unshrink (trajectories, options) {
+
+    var MIN_DATE_UNIX_TIMESTAMP = new Date("2015-05-15").getTime() / 1000; // seconds
+    var MIN_SIGNAL_STRENGTH = -110; // dB
+    var PRECISION_SIGNAL_STRENGTH = 5; // dB
+    var PRECISION_DATE = 30; // seconds
+
+    if (options) {
+        MIN_DATE_UNIX_TIMESTAMP = options.minDateUnixTimestamp || MIN_DATE_UNIX_TIMESTAMP;
+        MIN_SIGNAL_STRENGTH = options.minSignalStrength || MIN_SIGNAL_STRENGTH;
+        PRECISION_SIGNAL_STRENGTH = options.precisionSignalStrength || PRECISION_SIGNAL_STRENGTH;
+        PRECISION_DATE = options.precisionDate || PRECISION_DATE;
+    }
+
     return trajectories.map(function (trajectory) {
         return trajectory.map(function (measurement) {
             return {
-                date: unshrinkDate(measurement.date),
-                signal_strength: unshrinkSignal(measurement.signal_strength)
+                date: unshrinkDate(measurement.date, MIN_DATE_UNIX_TIMESTAMP, PRECISION_DATE),
+                signal_strength: unshrinkSignal(measurement.signal_strength, MIN_SIGNAL_STRENGTH, PRECISION_SIGNAL_STRENGTH)
             };
         });
     });


### PR DESCRIPTION
## TODO
- [x] Find a way to reduce the variance data cost. 
  - At the moment, they are delta encoded (as integers)
