### PR TITLE
Remove [packed=true] for non-repeated fields

### DIFF
--- a/trajectories/delta-encoded-measurement.proto
+++ b/trajectories/delta-encoded-measurement.proto
@@ -1,6 +1,6 @@
 message deviceTrajectory {
-  required bytes dates = 1 [packed=true];
-  required bytes signal_strengths = 2 [packed=true];
+  required bytes dates = 1;
+  required bytes signal_strengths = 2;
 }
 
 message trajectories {


### PR DESCRIPTION
In any case, `bytes` is not a type that can be packed
